### PR TITLE
Fix #76: Crash on Android since after egui-0.31

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -880,6 +880,7 @@ dependencies = [
  "egui-winit",
  "egui_demo_lib",
  "log",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,13 @@ features = [
     "default_fonts",
 ]
 
+[target.'cfg(target_os = "android")'.dependencies.wgpu]
+version = "27"
+default-features = false
+features = [
+    "gles",
+]
+
 # Used to get same winit used by eframe.
 [target.'cfg(target_os = "android")'.dependencies.egui-winit]
 version = "0.33"


### PR DESCRIPTION
Reenable gles backend after no longer being part of wgpu without
default features.
